### PR TITLE
Special characters sometimes breaks SQL INSERT

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -84,7 +84,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     if source then
         PlayerData.source = source
         PlayerData.license = PlayerData.license or QBCore.Functions.GetIdentifier(source, 'license')
-        PlayerData.name = GetPlayerName(source)
+        PlayerData.name = GetPlayerName(source):gsub("%W","")
         Offline = false
     end
 


### PR DESCRIPTION
Experienced earlier today, anyone with a special name such as "ꜱʜᴀᴅʏ𝘅" will cause a DB error due to MariaDB not being able to store those characters.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
